### PR TITLE
Update gst-plugin Makefile

### DIFF
--- a/src/gst-plugin/Makefile
+++ b/src/gst-plugin/Makefile
@@ -22,7 +22,7 @@ EXTRA_LDLIBS += -lkaldi-online -lkaldi-lat -lkaldi-decoder -lkaldi-feat -lkaldi-
 
 OBJFILES = gst-audio-source.o gst-online-gmm-decode-faster.o
 
-LIBNAME=gstkaldi
+LIBNAME=gstonlinegmmdecodefaster
 
 LIBFILE = lib$(LIBNAME).so
 BINFILES= $(LIBFILE)


### PR DESCRIPTION
The plugin is not recognised as valid when using the gstreamer master branch because the symname is extracted from the filename, https://github.com/GStreamer/gstreamer/blob/master/gst/gstplugin.c#L685